### PR TITLE
#1:: use server-side rendering.

### DIFF
--- a/components/LinkList.tsx
+++ b/components/LinkList.tsx
@@ -1,35 +1,14 @@
 import React from 'react';
 import Link from './Link';
-import { useQuery, gql } from '@apollo/client';
 
-const FEED_QUERY = gql`
-  {
-    feed {
-      id
-      links {
-        id
-        createdAt
-        url
-        description
-      }
-    }
-  }
-`
-    ;
-
-const LinkList = () => {
-    const { data, loading } = useQuery(FEED_QUERY);
-
+const LinkList = ({ linksToRender }: any) => {
+  //The following line is commented and left in the code for reference purpose.
+  // const { data, loading } = useQuery(FEED_QUERY);
     return (
-        <div>
-            {loading && (
-                <p>Apollo is fetching data for you. 🐶 ⃗🦴 ⃗🙋</p>
-            )
-
-            }
-            {data && (
+      <div>
+        {linksToRender && (
                 <>
-                    {data.feed.links.map((link: any) => (
+            {linksToRender.feed.links.map((link: any) => (
                         <Link key={link.id} link={link} />
                     ))}
                 </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ const httpLink = createHttpLink({
   uri: 'http://localhost:4000'
 });
 
-const client = new ApolloClient({
+export const client = new ApolloClient({
   link: httpLink,
   cache: new InMemoryCache()
 });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,10 +2,10 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import Image from 'next/image'
 import styles from '../styles/Home.module.css'
-import classNames from 'classnames'
 import LinkList from '../components/LinkList'
-
-const Home: NextPage = () => {
+import { gql } from '@apollo/client';
+import { client } from './_app'
+const Home: NextPage = ({ data }: any) => {
   return (
     <div className={styles.container}>
       <Head>
@@ -15,10 +15,33 @@ const Home: NextPage = () => {
       </Head>
 
       <main className={styles.main}>
-        <LinkList />
+        <LinkList linksToRender={data} />
       </main>
     </div>
   )
+}
+
+const FEED_QUERY = gql`
+  {
+    feed {
+      id
+      links {
+        id
+        createdAt
+        url
+        description
+      }
+    }
+  }
+`
+  ;
+
+export async function getServerSideProps() {
+  const { data } = await client.query({
+    query: FEED_QUERY
+  })
+
+  return { props: { data } }
 }
 
 export default Home


### PR DESCRIPTION
Inside the[ index.tsx](https://github.com/subha-accelo/q3-ddt-hackernews-nextjs-apollo-graphql/blob/main/pages/index.tsx) we now use the `getServerSideProps` to send a graphql query to get the data and then build the component with that data being passed as props. 

Next will then render the component on the server side and then serve it as the response to the request. 

Exercise:

1. Observe the Network tab on the browser to see if there are any requests being sent to the backend graphql api.
2. Check the response for `get localhost:3000`